### PR TITLE
`notary add` against a specific file

### DIFF
--- a/client/isolated.go
+++ b/client/isolated.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/notary"
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/tuf/data"
+	"github.com/docker/notary/tuf/signed"
+	"io"
+	"io/ioutil"
+)
+
+// AddTargetToFile adds the target to the file found at filePath, and writes the updated and re-signed version
+// to the outBuf.
+// If signingKeys are provided, they are used to sign the file. If lookupKeys are provided, they
+// will be looked up in the CryptoService and used for signing where found.
+// If _both_ signingKeys, and lookupKeys are provided, the public keys in lookupKeys will be added to signingKeys
+// and the merged list will be used for signing.
+// If _neither_ signingKeys, no lookupKeys are provided, the key IDs associated with any existing signatures are
+// used to search for keys in the CryptoService and used to sign.
+func AddTargetToFile(baseDir string, retriever notary.PassRetriever, outBuf io.Writer, filePath string, target *Target, signingKeys map[string]data.PrivateKey, lookupKeys map[string]data.PublicKey) error {
+	// do some setup
+	var fakeRole data.RoleName = data.CanonicalTargetsRole
+	ks, err := getKeyStores(baseDir, retriever)
+	if err != nil {
+		return err
+	}
+	cs := cryptoservice.NewCryptoService(ks...)
+
+	var parsed *data.SignedTargets
+	if filePath == "-" {
+		// setting the filePath to "-" indicates we have no starting file, a new one should be created
+		parsed = data.NewTargets()
+	} else {
+		// read and parse input file
+		file, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return err
+		}
+
+		parsed = &data.SignedTargets{}
+		err = json.Unmarshal(file, parsed)
+		if err != nil {
+			return err
+		}
+	}
+
+	// add target
+	parsed.Signed.Targets[target.Name] = data.FileMeta{
+		Length: target.Length,
+		Hashes: target.Hashes,
+	}
+
+	// sign file
+	parsed.Signed.Expires = data.DefaultExpires(fakeRole)
+	parsed.Signed.Version = parsed.Signed.Version + 1
+	signedObj, err := parsed.ToSigned()
+	if err != nil {
+		return err
+	}
+
+	if signingKeys == nil {
+		// just in case, we don't want to panic when we try and assign
+		signingKeys = make(map[string]data.PrivateKey)
+	}
+	for canonID, pubKey := range lookupKeys {
+		privKey, _, err := cs.GetPrivateKey(canonID)
+		if err != nil {
+			// log the canonical ID as this would be the filename the person should look for
+			logrus.Errorf("key with ID %s not found", canonID)
+			continue
+		}
+		signingKeys[pubKey.ID()] = privKey
+	}
+
+	err = signIsolated(cs, signedObj, signingKeys)
+	if err != nil {
+		return err
+	}
+
+	// marshal and output to write buffer
+	out, err := json.Marshal(signedObj)
+	if err != nil {
+		return err
+	}
+	n, err := outBuf.Write(out)
+	if n < len(out) {
+		return errors.New("failed to write all output data")
+	}
+	return err
+}
+
+func signIsolated(cs signed.CryptoService, signedObj *data.Signed, signingKeys map[string]data.PrivateKey) error {
+	if len(signingKeys) > 0 {
+		return signed.SignWithPrivateKeys(
+			signedObj,
+			signingKeys,
+			nil,
+		)
+	}
+	// collect key IDs from current signatures
+	keys := make([]data.PublicKey, 0, len(signedObj.Signatures))
+	for _, sig := range signedObj.Signatures {
+		logrus.Info("no signing keys provided, attempting to look up keys bsaed on existing signature key IDs.")
+		key := cs.GetKey(sig.KeyID)
+		if key == nil {
+			logrus.Infof("unable to find key with ID %s", sig.KeyID)
+			continue
+		}
+		keys = append(keys, key)
+	}
+	if len(keys) == 0 {
+		return errors.New("unable to find any signing keys")
+	}
+	return signed.Sign(
+		cs,
+		signedObj,
+		keys,
+		1,
+		nil,
+	)
+}

--- a/client/isolated_test.go
+++ b/client/isolated_test.go
@@ -1,0 +1,176 @@
+package client
+
+import (
+	"bytes"
+	"crypto/rand"
+	"github.com/docker/notary"
+	"github.com/docker/notary/cryptoservice"
+	"github.com/docker/notary/trustmanager"
+	"github.com/docker/notary/tuf/data"
+	tufutils "github.com/docker/notary/tuf/utils"
+	"github.com/stretchr/testify/require"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func TestSignIsolated(t *testing.T) {
+	privKey, err := tufutils.GenerateECDSAKey(rand.Reader)
+	require.NoError(t, err)
+
+	tgt := data.NewTargets()
+	sgnd, err := tgt.ToSigned()
+	require.NoError(t, err)
+
+	require.NoError(t, signIsolated(
+		nil, // we don't use the cryptoservice when specific private keys are provided
+		sgnd,
+		map[string]data.PrivateKey{
+			privKey.ID(): privKey,
+		},
+	))
+
+	cs := cryptoservice.NewCryptoService(
+		trustmanager.NewKeyMemoryStore(passphraseRetriever),
+	)
+
+	// no signing keys provided and no keys in cryptoservice
+	require.Error(t, signIsolated(
+		cs, // we don't use the cryptoservice when specific private keys are provided
+		sgnd,
+		nil,
+	))
+
+	// add the key
+	require.NoError(t, cs.AddKey("targets", "", privKey))
+
+	// allow key to be detected via signature key ID
+	require.NoError(t, signIsolated(
+		cs, // we don't use the cryptoservice when specific private keys are provided
+		sgnd,
+		nil,
+	))
+}
+
+func TestAddTargetToFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "notary-test-")
+	require.NoError(t, err)
+
+	privKey, err := tufutils.GenerateECDSAKey(rand.Reader)
+	require.NoError(t, err)
+
+	out := new(bytes.Buffer)
+
+	require.NoError(t, AddTargetToFile(
+		tmpDir,
+		passphraseRetriever,
+		out,
+		"-", // create a new file
+		&Target{
+			Name: "isolated",
+			Hashes: data.Hashes{
+				notary.SHA256: []byte("abcdef"),
+			},
+			Length: 0xdeadbeef,
+		},
+		map[string]data.PrivateKey{
+			privKey.ID(): privKey,
+		},
+		nil,
+	))
+
+	tmpFile, err := ioutil.TempFile("", "notary-test-targets-")
+	require.NoError(t, err)
+
+	io.Copy(tmpFile, out)
+	tmpFile.Close()
+
+	filePath := tmpFile.Name()
+
+	// check we error when no keys are provided and no keys are in the key storage
+	require.Error(t, AddTargetToFile(
+		tmpDir,
+		passphraseRetriever,
+		out,
+		filePath,
+		&Target{
+			Name: "isolated",
+			Hashes: data.Hashes{
+				notary.SHA256: []byte("abcdef"),
+			},
+			Length: 0xdeadbeef,
+		},
+		nil,
+		nil,
+	))
+
+	// reset out buffer
+	out = new(bytes.Buffer)
+
+	require.NoError(t, AddTargetToFile(
+		tmpDir,
+		passphraseRetriever,
+		out,
+		filePath,
+		&Target{
+			Name: "isolated",
+			Hashes: data.Hashes{
+				notary.SHA256: []byte("abcdef"),
+			},
+			Length: 0xdeadbeef,
+		},
+		map[string]data.PrivateKey{
+			privKey.ID(): privKey,
+		},
+		nil,
+	))
+
+	// Add private key to key stores and check we can sign when
+	// looking up the signature ID
+	ks, err := getKeyStores(tmpDir, passphraseRetriever)
+	require.NoError(t, err)
+	cs := cryptoservice.NewCryptoService(ks...)
+	err = cs.AddKey("targets", "", privKey)
+	require.NoError(t, err)
+
+	// reset out buffer
+	out = new(bytes.Buffer)
+
+	require.NoError(t, AddTargetToFile(
+		tmpDir,
+		passphraseRetriever,
+		out,
+		filePath, // create a new file
+		&Target{
+			Name: "isolated",
+			Hashes: data.Hashes{
+				notary.SHA256: []byte("abcdef"),
+			},
+			Length: 0xdeadbeef,
+		},
+		nil,
+		nil,
+	))
+
+	// reset out buffer
+	out = new(bytes.Buffer)
+
+	// check that we can sign when we provide lookup keys that are in the key store.
+	require.NoError(t, AddTargetToFile(
+		tmpDir,
+		passphraseRetriever,
+		out,
+		"-", // create a new file to guarantee we're not looking up signature key IDs
+		&Target{
+			Name: "isolated",
+			Hashes: data.Hashes{
+				notary.SHA256: []byte("abcdef"),
+			},
+			Length: 0xdeadbeef,
+		},
+		nil,
+		map[string]data.PublicKey{
+			privKey.ID(): data.PublicKeyFromPrivate(privKey),
+		},
+	))
+}

--- a/cmd/notary/util_test.go
+++ b/cmd/notary/util_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/notary/passphrase"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,4 +52,21 @@ func TestFeedback(t *testing.T) {
 	content, err := ioutil.ReadFile(file.Name())
 	require.NoError(t, err)
 	require.Equal(t, "", string(content))
+}
+
+func TestParseKeysCerts(t *testing.T) {
+	privKeys, certs := parseKeysCerts(
+		passphrase.ConstantRetriever(testPassphrase),
+		[]string{
+			"../../fixtures/testkeys/targets_releases.priv",
+		},
+		[]string{
+			"../../fixtures/testkeys/targets_releases.pub",
+			"../../fixtures/testkeys/targets_qa.pub",
+		},
+	)
+	// we should match the target_releases pub and priv keys and
+	// end up with one entry in each map.
+	require.Len(t, privKeys, 1)
+	require.Len(t, certs, 1)
 }

--- a/fixtures/testkeys/targets_qa.priv
+++ b/fixtures/testkeys/targets_qa.priv
@@ -1,0 +1,9 @@
+-----BEGIN EC PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-256-CBC,24e89012de0364ae7e6a40023048ade1
+role: targets/releases
+
+G3W+mR6KazkjpDEBM625NgttNleQ5k5flogcKc/m6RwKWdrBTOmWYT8QmD2Wg6IE
+z3QH98X29+jA4LdiUY8PMftSLX/dh3S30v1vbUvkKxJ2U7LjS1jeOksygpBUSXc5
+lg1if2WgaehiAY1IkDXGeNIM/GBThIolhqebuRpURZM=
+-----END EC PRIVATE KEY-----

--- a/fixtures/testkeys/targets_qa.pub
+++ b/fixtures/testkeys/targets_qa.pub
@@ -1,0 +1,6 @@
+-----BEGIN PUBLIC KEY-----
+role: targets/releases
+
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoE5u6DkDwVnI52cFlYdIzDC+9lfR
+WUVV4IcfiwQzulmg0Icj7/JmrXq1SVjKE9Naa1INXEjLEn6ii+21tv3i1A==
+-----END PUBLIC KEY-----

--- a/fixtures/testkeys/targets_releases.priv
+++ b/fixtures/testkeys/targets_releases.priv
@@ -1,0 +1,9 @@
+-----BEGIN EC PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-256-CBC,601e89562b2713552d762bbb4fc6cc3b
+role: targets/releases
+
+HCbJQOUTliNkPutqrP+kHa9JMz5xbTMpi0o6Xs2Mv/07LR9LoU0/Nnq1nv0L+mPh
+2sssRWJgrCbuOB0oMwkcckQaDK0NNvWn0kgzo0m83o7NepXWT2K5EwdYVhEyDAmA
+Jg1ix6St/MepLo6B7qi33zLMMaUd2ZsoTPz+xC9a4lU=
+-----END EC PRIVATE KEY-----

--- a/fixtures/testkeys/targets_releases.pub
+++ b/fixtures/testkeys/targets_releases.pub
@@ -1,0 +1,6 @@
+-----BEGIN PUBLIC KEY-----
+role: targets/releases
+
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/BBk0g+8Q9NXbjZlL4OxEIuWnuqe
+EOa2E7yljHNChnnBfCvMpYXcdHKMDCBAAHEABqaQiJaBzMMLWJhYz+RvvA==
+-----END PUBLIC KEY-----


### PR DESCRIPTION
- Adds a `-i/--input` flag to `notary add` and `notary addhash`. When provided, rather than creating a changelist item, the target will be added to the file provided.
  - Setting the value of `-i/--input` to `"-"` will cause a new targets file to be created. This also requires that at least one of `--keys` or `--certs` are provided as the new targets file will have no signatures from which we can look up existing keys.
- Adds `--keys` and `--certs` flags to `notary add` and `notary addhash`. 
  - If `--keys` are provided, they will be used for signing the modified file.
  - If `--certs` are provided, they are cross referenced with any items in `--keys` and where the Canonical IDs match, the _Non_-Canonical ID is used when adding the resultant signature. Any `--certs` that don't match a `--keys` entry are looked up in the CryptoService and merged with the entries from `--keys`.
  - If neither `--keys` or `--certs` are provided, we will attempt to re-sign the file with any keys for which there is an existing signature on the provided `-i/--input`.

Result is output to the file provided by the `-o/--output` option. The flag is required in the case `-i/--input` is used. 

Begins to address #1120 

cc @riyazdf (if you have time) and @n4ss so you can test it with your export/import code.

Signed-off-by: David Lawrence <david.lawrence@docker.com> (github: endophage)