### PR TITLE
Feature/sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,24 @@ git commit -m "Upgraded github.com/spf13/viper"
 
 The `buildscripts/circle-validate-vendor.sh` runs `go mod tidy` and `go mod vendor` using the given version of Go to prevent differences if you are for example running on a different version of Go.
 
+## Run in a sandbox
+
+To run your experiments in a completely isolated sandbox you could leverage the `docker-compose.sandbox.yml`. To build the sandbox image ensure to run `make cross` first (the image needs a linux build).
+
+Now you can run:
+
+```bash
+docker-compose -f docker-compose.sandbox.yml up -d --build
+$ docker-compose -f docker-compose.sandbox.yml exec sandbox sh
+/ # which notary
+/usr/local/bin/notary
+/ # which docker
+/usr/local/bin/docker
+/ #
+```
+
+From within the sandbox container you can play with notary and `docker trust` without worrying about messing up your local environment.
+
 ## Building Notary
 
 Note that Notary's [latest stable release](https://github.com/theupdateframework/notary/releases) is at the head of the

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -81,6 +81,31 @@ services:
         update-ca-certificates &&
         dockerd-entrypoint.sh --insecure-registry registry:5000'
 
+  # This sandbox can be used for testing delegation keys;
+  # There is no mount to the shared docker trust folder!
+  # So if you want to pull push etc, you need to export delegation keys from the sandbox
+  # to this sandbox and load them with docker trust key load.
+  sandbox-2:
+    image: notary:sandbox-dev
+    build:
+      context: .
+      dockerfile: sandbox.Dockerfile
+    networks:
+      - sig
+    volumes:
+      - go_modules:/go/pkg/mod
+    depends_on:
+      - server
+    privileged: true
+    environment:
+      DOCKER_CONTENT_TRUST: "1"
+      DOCKER_CONTENT_TRUST_SERVER: https://notary-server:4443
+    entrypoint: /usr/bin/env sh
+    command: |-
+      -c 'cp ~/.notary/certs/root-ca.crt /usr/local/share/ca-certificates/root-ca.crt &&
+        update-ca-certificates &&
+        dockerd-entrypoint.sh --insecure-registry registry:5000'
+        
 volumes:
   go_modules:
   dct_data:

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -1,0 +1,86 @@
+version: "2"
+services:
+  server:
+    image: notary:server-dev
+    build:
+      context: .
+      dockerfile: server.Dockerfile
+    networks:
+      mdb:
+      sig:
+        aliases:
+          - notary-server
+    ports:
+      - "8080"
+      - "4443:4443"
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-server -config=fixtures/server-config.json"
+    depends_on:
+      - mysql
+      - signer
+
+  signer:
+    image: notary:signer-dev
+    build:
+      context: .
+      dockerfile: signer.Dockerfile
+    networks:
+      mdb:
+      sig:
+        aliases:
+          - notarysigner
+    entrypoint: /usr/bin/env sh
+    command: -c "./migrations/migrate.sh && notary-signer -config=fixtures/signer-config.json"
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mariadb:10.4
+    networks:
+      - mdb
+    volumes:
+      - ./notarysql/mysql-initdb.d:/docker-entrypoint-initdb.d
+      - notary_data:/var/lib/mysql
+    environment:
+      TERM: dumb
+      MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+    command: mysqld --innodb_file_per_table
+
+  registry:
+    image: registry:2.7
+    environment:
+      REGISTRY_HTTP_SECRET: topS3cr3t
+    networks:
+      - sig
+
+  sandbox:
+    image: notary:sandbox-dev
+    build:
+      context: .
+      dockerfile: sandbox.Dockerfile
+    networks:
+      - sig
+    volumes:
+      - dct_data:/root/.docker/trust:rw
+    depends_on:
+      - server
+    privileged: true
+    environment:
+      DOCKER_CONTENT_TRUST: "1"
+      DOCKER_CONTENT_TRUST_SERVER: https://notary-server:4443
+    entrypoint: /usr/bin/env sh
+    command: |-
+      -c 'cp ~/.notary/certs/root-ca.crt /usr/local/share/ca-certificates/root-ca.crt &&
+        update-ca-certificates &&
+        dockerd-entrypoint.sh --insecure-registry registry:5000'
+
+volumes:
+  dct_data:
+    external: false
+  notary_data:
+    external: false
+networks:
+  mdb:
+    external: false
+  sig:
+    external: false

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -50,6 +50,8 @@ services:
     image: registry:2.7
     environment:
       REGISTRY_HTTP_SECRET: topS3cr3t
+    ports:
+      - "5000:5000"
     networks:
       - sig
 

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: server.Dockerfile
+    volumes:
+      - go_modules:/go/pkg/mod
     networks:
       mdb:
       sig:
@@ -24,6 +26,8 @@ services:
     build:
       context: .
       dockerfile: signer.Dockerfile
+    volumes:
+      - go_modules:/go/pkg/mod
     networks:
       mdb:
       sig:
@@ -64,6 +68,7 @@ services:
       - sig
     volumes:
       - dct_data:/root/.docker/trust:rw
+      - go_modules:/go/pkg/mod
     depends_on:
       - server
     privileged: true
@@ -77,6 +82,7 @@ services:
         dockerd-entrypoint.sh --insecure-registry registry:5000'
 
 volumes:
+  go_modules:
   dct_data:
     external: false
   notary_data:

--- a/fixtures/sandbox-config.json
+++ b/fixtures/sandbox-config.json
@@ -2,9 +2,9 @@
     "trust_dir": "~/.docker/trust",
     "remote_server": {
         "url": "https://notary-server:4443",
-        "root_ca": "~/.notary/certs/root-ca.crt",
-        "tls_client_key": "~/.notary/certs/notary-server.key",
-        "tls_client_cert": "~/.notary/certs/notary-server.crt",
+        "root_ca": "./certs/root-ca.crt",
+        "tls_client_key": "./certs/notary-server.key",
+        "tls_client_cert": "./certs/notary-server.crt",
         "skipTLSVerify": true
     }
 }

--- a/fixtures/sandbox-config.json
+++ b/fixtures/sandbox-config.json
@@ -1,0 +1,10 @@
+{
+    "trust_dir": "~/.docker/trust",
+    "remote_server": {
+        "url": "https://notary-server:4443",
+        "root_ca": "~/.notary/certs/root-ca.crt",
+        "tls_client_key": "~/.notary/certs/notary-server.key",
+        "tls_client_cert": "~/.notary/certs/notary-server.crt",
+        "skipTLSVerify": true
+    }
+}

--- a/sandbox.Dockerfile
+++ b/sandbox.Dockerfile
@@ -1,0 +1,13 @@
+FROM docker:dind
+
+COPY cross/linux/amd64/notary /usr/local/bin/notary
+
+WORKDIR /root
+
+RUN mkdir -p .notary/certs && mkdir -p .docker/trust
+
+VOLUME [ "/root/.docker/trust" ]
+
+COPY fixtures/notary-server.key fixtures/notary-server.crt fixtures/root-ca.crt /root/.notary/certs/
+
+COPY fixtures/sandbox-config.json /root/.notary/config.json


### PR DESCRIPTION
This PR adds a docker-compose setup that can be utilized to have a sandbox available for playing with notary and docker content trust.

resolves #1561 which was included by rebasing on top of #1560 