### PR TITLE
Add index for GUN on tuf_files

### DIFF
--- a/migrations/server/mysql/0006_index_gun_tuf_files.up.sql
+++ b/migrations/server/mysql/0006_index_gun_tuf_files.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tuf_files` ADD INDEX `gun_idx` (`gun`);


### PR DESCRIPTION
At work my team uses Notary and we encountered a serious inefficiency when it comes to database queries from the `tuf_files` table. The table lacks an index on the `gun` field, which makes the MySQL/MariaDB engine perform a full table scan each time `gun` is used in a `WHERE` clause (which most Notary server endpoints use). We have lots of repositories indexed in `tuf_files`, which started to become a problem and we noticed this issue.

A default BTree index on `gun` makes sense since GUNs are tree-like in nature (they are even represented like directory structures on disk). Making this change in our environment sped up the Notary server significantly.

Note: Just to avoid confusion, it is important to mention that there is an index on `tuf_files` called `gun`, but it is a composite UNIQUE KEY index consisting of `gun`, `role` and `version`. This index doesn't help when there is a `WHERE` clause involving the `gun` column alone, so the DB engine performs a full table scan anyway.