### PR TITLE
Fix role parsing in golang 1.17+

### DIFF
--- a/server/handlers/default.go
+++ b/server/handlers/default.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -72,7 +73,12 @@ func atomicUpdateHandler(ctx context.Context, w http.ResponseWriter, r *http.Req
 		if err == io.EOF {
 			break
 		}
-		role := data.RoleName(strings.TrimSuffix(part.FileName(), ".json"))
+		_, params, err := mime.ParseMediaType(part.Header.Get("Content-Disposition"))
+		if err != nil {
+			logger.Infof("400 POST error parsing Content-Disposition header: %s", err)
+			return errors.ErrNoFilename.WithDetail(nil)
+		}
+		role := data.RoleName(strings.TrimSuffix(params["filename"], ".json"))
 		if role.String() == "" {
 			logger.Info("400 POST empty role")
 			return errors.ErrNoFilename.WithDetail(nil)


### PR DESCRIPTION
In golang 1.17 [a change was made](https://go.dev/doc/go1.17#minor_library_changes) to remove anything preceding a slash from the filename field of the Content-Disposition header. This causes a problem with notary since it's using the filename field for the role value. This fix changes the parsing of the header value so it grabs the raw filename value instead of using the method that removes the base part of the filename.

This is also outlined in this issue:
https://github.com/notaryproject/notary/issues/1630
