### PR TITLE
Fix race condition in `UpdateMany`

### DIFF
--- a/development.mysql.yml
+++ b/development.mysql.yml
@@ -30,7 +30,9 @@ services:
       - mysql
   mysql:
     networks:
-      - mdb
+      mdb:
+        aliases:
+          - mysql
     volumes:
       - ./notarysql/mysql-initdb.d:/docker-entrypoint-initdb.d
     image: mariadb:10.4

--- a/development.postgresql.yml
+++ b/development.postgresql.yml
@@ -37,7 +37,9 @@ services:
   postgresql:
     image: postgres:9.5.4
     networks:
-      - mdb 
+      mdb:
+        aliases:
+          - postgresql
     volumes:
       - ./notarysql/postgresql-initdb.d:/docker-entrypoint-initdb.d
     command: -l

--- a/server/storage/concurrent_sqldb_test.go
+++ b/server/storage/concurrent_sqldb_test.go
@@ -1,0 +1,93 @@
+//go:build mysqldb || postgresqldb
+// +build mysqldb postgresqldb
+
+package storage
+
+import (
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jinzhu/gorm"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/notary/tuf/data"
+)
+
+func init() {
+	// Get the connection string from an environment variable
+	dburl := os.Getenv("DBURL")
+	if dburl == "" {
+		logrus.Fatal("DBURL environment variable not set")
+	}
+
+	for i := 0; i <= 30; i++ {
+		gormDB, err := gorm.Open(backend, dburl)
+		if err == nil {
+			err := gormDB.DB().Ping()
+			if err == nil {
+				break
+			}
+		}
+		if i == 30 {
+			logrus.Fatalf("Unable to connect to %s after 60 seconds", dburl)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	sqldbSetup = func(t *testing.T) (*SQLStorage, func()) {
+		var dropTables = func(gormDB *gorm.DB) {
+			// drop all tables, if they exist
+			gormDB.DropTable(&TUFFile{})
+			gormDB.DropTable(&SQLChange{})
+		}
+		gormDB, err := gorm.Open(backend, dburl)
+		require.NoError(t, err)
+		dropTables(gormDB)
+		gormDB.Close()
+		dbStore := SetupSQLDB(t, backend, dburl)
+		return dbStore, func() {
+			dropTables(&dbStore.DB)
+			dbStore.Close()
+		}
+	}
+}
+
+// TestSQLUpdateManyConcurrentConflictRollback asserts that if several concurrent requests
+// to store tuf files with the same gun, role, and version, that exactly one of them succeeds.
+func TestSQLUpdateManyConcurrentConflictRollback(t *testing.T) {
+	dbStore, cleanup := sqldbSetup(t)
+	defer cleanup()
+
+	var gun data.GUN = "testGUN"
+	concurrency := 50
+	var wg sync.WaitGroup
+
+	errCh := make(chan error)
+
+	for i := 0; i < concurrency; i++ {
+		tufObj := SampleCustomTUFObj(gun, data.CanonicalRootRole, 1, []byte{byte(i)})
+		updates := []MetaUpdate{MakeUpdate(tufObj)}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errCh <- dbStore.UpdateMany(gun, updates)
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+	}()
+
+	successes := 0
+	for err := range errCh {
+		if err == nil {
+			successes++
+		}
+	}
+
+	require.Equal(t, 1, successes)
+}

--- a/server/storage/mysql_test.go
+++ b/server/storage/mysql_test.go
@@ -6,52 +6,8 @@
 package storage
 
 import (
-	"os"
-	"testing"
-	"time"
-
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/jinzhu/gorm"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"github.com/theupdateframework/notary"
 )
 
-func init() {
-	// Get the MYSQL connection string from an environment variable
-	dburl := os.Getenv("DBURL")
-	if dburl == "" {
-		logrus.Fatal("MYSQL environment variable not set")
-	}
-
-	for i := 0; i <= 30; i++ {
-		gormDB, err := gorm.Open("mysql", dburl)
-		if err == nil {
-			err := gormDB.DB().Ping()
-			if err == nil {
-				break
-			}
-		}
-		if i == 30 {
-			logrus.Fatalf("Unable to connect to %s after 60 seconds", dburl)
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	sqldbSetup = func(t *testing.T) (*SQLStorage, func()) {
-		var dropTables = func(gormDB *gorm.DB) {
-			// drop all tables, if they exist
-			gormDB.DropTable(&TUFFile{})
-			gormDB.DropTable(&SQLChange{})
-		}
-		gormDB, err := gorm.Open(notary.MySQLBackend, dburl)
-		require.NoError(t, err)
-		dropTables(gormDB)
-		gormDB.Close()
-		dbStore := SetupSQLDB(t, notary.MySQLBackend, dburl)
-		return dbStore, func() {
-			dropTables(&dbStore.DB)
-			dbStore.Close()
-		}
-	}
-}
+var backend = notary.MySQLBackend

--- a/server/storage/postgresql_test.go
+++ b/server/storage/postgresql_test.go
@@ -6,52 +6,8 @@
 package storage
 
 import (
-	"os"
-	"testing"
-	"time"
-
-	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/require"
 	"github.com/theupdateframework/notary"
 )
 
-func init() {
-	// Get the PostgreSQL connection string from an environment variable
-	dburl := os.Getenv("DBURL")
-	if dburl == "" {
-		logrus.Fatal("PostgreSQL environment variable not set")
-	}
-
-	for i := 0; i <= 30; i++ {
-		gormDB, err := gorm.Open(notary.PostgresBackend, dburl)
-		if err == nil {
-			err := gormDB.DB().Ping()
-			if err == nil {
-				break
-			}
-		}
-		if i == 30 {
-			logrus.Fatalf("Unable to connect to %s after 60 seconds", dburl)
-		}
-		time.Sleep(2 * time.Second)
-	}
-
-	sqldbSetup = func(t *testing.T) (*SQLStorage, func()) {
-		var dropTables = func(gormDB *gorm.DB) {
-			// drop all tables, if they exist
-			gormDB.DropTable(&TUFFile{})
-			gormDB.DropTable(&SQLChange{})
-		}
-		gormDB, err := gorm.Open(notary.PostgresBackend, dburl)
-		require.NoError(t, err)
-		dropTables(gormDB)
-		gormDB.Close()
-		dbStore := SetupSQLDB(t, notary.PostgresBackend, dburl)
-		return dbStore, func() {
-			dropTables(&dbStore.DB)
-			dbStore.Close()
-		}
-	}
-}
+var backend = notary.PostgresBackend

--- a/server/storage/sqldb_test.go
+++ b/server/storage/sqldb_test.go
@@ -1,3 +1,4 @@
+//go:build !rethinkdb
 // +build !rethinkdb
 
 package storage

--- a/server/storage/sqldb_test.go
+++ b/server/storage/sqldb_test.go
@@ -67,8 +67,6 @@ func TestSQLUpdateCurrentEmpty(t *testing.T) {
 
 	expected := testUpdateCurrentEmptyStore(t, dbStore)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLUpdateCurrentVersionCheckOldVersionExists asserts that UpdateCurrent will add a
@@ -80,8 +78,6 @@ func TestSQLUpdateCurrentVersionCheckOldVersionExists(t *testing.T) {
 
 	expected := testUpdateCurrentVersionCheck(t, dbStore, true)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLUpdateCurrentVersionCheckOldVersionNotExist asserts that UpdateCurrent will add a
@@ -93,8 +89,6 @@ func TestSQLUpdateCurrentVersionCheckOldVersionNotExist(t *testing.T) {
 
 	expected := testUpdateCurrentVersionCheck(t, dbStore, false)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLUpdateManyNoConflicts asserts that inserting multiple updates succeeds if the
@@ -106,8 +100,6 @@ func TestSQLUpdateManyNoConflicts(t *testing.T) {
 
 	expected := testUpdateManyNoConflicts(t, dbStore)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLUpdateManyConflictRollback asserts that no data ends up in the DB if there is
@@ -118,8 +110,6 @@ func TestSQLUpdateManyConflictRollback(t *testing.T) {
 
 	expected := testUpdateManyConflictRollback(t, dbStore)
 	assertExpectedGormTUFMeta(t, expected, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLDelete asserts that Delete will remove all TUF metadata, all versions,
@@ -130,8 +120,6 @@ func TestSQLDelete(t *testing.T) {
 
 	testDeleteSuccess(t, dbStore)
 	assertExpectedGormTUFMeta(t, nil, dbStore.DB)
-
-	dbStore.DB.Close()
 }
 
 // TestSQLDBCheckHealthTableMissing asserts that the health check fails if the table is missing


### PR DESCRIPTION
There is a race condition in the `UpdateMany` method on `SQLStorage`. This race condition means that if the `POST /v2/{gun}/_trust/tuf/` endpoint is called concurrently, tuf_files with the same gun/role/version in different requests can silently overwrite each other. This can cause data corruption if a snapshot is generated that references a file that is later overwritten.

The current code has two measures in place to prevent this from happening: a unique index on the gun/role/version combination, and an up-front check that there are no existing files with the same gun/role and an equal or greater version to those being created. The up-front check doesn't use any locking so it doesn't prevent concurrent requests with files that would match. The unique index should be enough, but at the moment we use gorm's `FirstOrCreate` to do the insert, which actually updates any rows it finds with the data that would have been inserted (in this case this means overwriting the `data` and `sha256` fields). The main part of this fix is to just use `Create` instead and rely on the unique index to catch any duplicates. We also now support postgres and sqlite when checking for unique constraint errors.

We've kept the up-front check because it is still required to guard against the case where, for example, we have versions `1`, `2`, and `4`, and we try to insert `3`. We only need to check whether there are any existing files with versions equal or greater than the lowest version being inserted for each role. This results in fewer queries if inserting multiple files with the same role.

If the database currently contains versions `1` and `2`, we can still concurrently try to insert `3` and `4` and have `4` insert before `3`. We might be able to stop this with serializable transactions, but I don't think it's a very important problem.

This PR also fixes up the database tests and adds a test for the race condition.
