### PR TITLE
Fix static binary build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 version: 2
 jobs:
-
   job_01:
     machine:
       image: ubuntu-1604:201903-01
@@ -52,6 +51,9 @@ jobs:
           name: "Build image"
           command: docker build --progress=plain -t notary_client .
       - run:
+          name: "Build static binaries"
+          command: docker run --rm -e NOTARY_BUILDTAGS --env-file buildscripts/env.list --user notary notary_client bash -c "make static"
+      - run:
           name: "ci"
           command: docker run --rm -e NOTARY_BUILDTAGS --env-file buildscripts/env.list --user notary notary_client bash -c "make ci && codecov"
       - run:
@@ -88,11 +90,10 @@ jobs:
           command: make TESTDB=mysql integration
       - run:
           name: "Cross"
-          command: make cross  # just trying not to exceed 4 builders
+          command: make cross # just trying not to exceed 4 builders
       - run:
           name: "Teardown"
           command: docker-compose -f docker-compose.yml down -v && docker-compose -f docker-compose.rethink.yml down -v
-
 
   job_04:
     machine:

--- a/server/storage/sqldb.go
+++ b/server/storage/sqldb.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/jinzhu/gorm"
 	"github.com/lib/pq"
-	"github.com/mattn/go-sqlite3"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/notary/tuf/data"
 )
@@ -47,10 +46,6 @@ func translateOldVersionError(err error) error {
 		// https://www.postgresql.org/docs/10/errcodes-appendix.html
 		// 23505 = unique_violation
 		if err.Code == "23505" {
-			return ErrOldVersion{}
-		}
-	case sqlite3.Error:
-		if err.ExtendedCode == sqlite3.ErrConstraintUnique {
 			return ErrOldVersion{}
 		}
 	}


### PR DESCRIPTION
Static builds are broken on `master` because of a change introduced in #1636 which added a dependency on the sqlite library which requires cgo. We don't actually support sqlite outside of tests so this PR removes the dependency. I've also added a CI step to build the static binaries to make sure this doesn't happen again.

We discovered this at Docker because [we use the static binaries to build](https://github.com/docker/notary-official-images/blob/master/notary-server/Dockerfile#L15) the [Docker Official Image](https://hub.docker.com/_/notary) for Notary.