### PR TITLE
Update "testclient.py" to work on Python 3

### DIFF
--- a/buildscripts/testclient.py
+++ b/buildscripts/testclient.py
@@ -294,7 +294,7 @@ class Tester(object):
         for test_func in (self.basic_repo_test, self.add_delegation_test, self.root_rotation_test):
             _, tempfile = mkstemp()
             with open(tempfile, 'wb') as handle:
-                handle.write(test_func.__name__ + "\n")
+                handle.write(bytes(str(test_func.__name__ + "\n").encode("utf-8")))
 
             tempdir = mkdtemp(suffix="_temp")
 


### PR DESCRIPTION
This one-line change is a little bit less clean-looking than I'd like, but this makes sure it works on both Python 2 _and_ Python 3. :smile:

I worked this up (and validated it) via https://github.com/docker/notary-official-images/pull/29. :eyes: :metal: