### PR TITLE
Remove unbounded cache

### DIFF
--- a/server/storage/tuf_store_test.go
+++ b/server/storage/tuf_store_test.go
@@ -74,22 +74,6 @@ func testTUFMetaStoreGetCurrent(t *testing.T, s MetaStore) {
 	require.NoError(t, s.UpdateMany(gun, updates))
 	_, _, err = s.GetCurrent(gun, data.CanonicalSnapshotRole)
 	require.IsType(t, ErrNotFound{}, err)
-
-	// GetCurrent on all roles should still succeed - snapshot lookup because of caching,
-	// and targets and root because the snapshot is cached
-	for _, tufobj := range tufMetaByRole {
-		ConsistentGetCurrentFoundTest(t, tufDBStore, tufobj)
-	}
-
-	// add another orphaned root, but ensure that we still get the previous root
-	// since the new root isn't in a timestamp/snapshot chain
-	orphanedRootTUF := SampleCustomTUFObj(gun, data.CanonicalRootRole, 3, []byte("orphanedRoot"))
-	require.NoError(t, s.UpdateCurrent(gun, MakeUpdate(orphanedRootTUF)), "unable to create orphaned root in store")
-
-	// a GetCurrent for this gun and root gets us the previous root, which is linked in timestamp and snapshot
-	ConsistentGetCurrentFoundTest(t, tufDBStore, tufMetaByRole[data.CanonicalRootRole.String()])
-	// the orphaned root fails on a GetCurrent even though it's in the underlying store
-	ConsistentTSAndSnapGetDifferentCurrentTest(t, tufDBStore, orphanedRootTUF)
 }
 
 func ConsistentGetCurrentFoundTest(t *testing.T, s *TUFMetaStorage, rec StoredTUFMeta) {


### PR DESCRIPTION
`TUFMetaStorage` uses an in-memory cache to store all retrieved metadata files. This cache has a few problems:

1. It doesn't have any sort of limit on its size so it will grow indefinitely as more content is retrieved
2. Entries in the cache are not deleted when `Delete` is calls on a `TUFMetaStorage` instance. This means the cache can hold entries that have been deleted from the underlying storage (there seem to be tests for this behavior so could this be for a reason?)
3. It isn't safe for concurrent use, see #1613.

I've taken the scorched-earth approach of simply removing this cache. After #1639 it should be fast to get these files from the database each time. I'll test this on Docker's production instance before merging it to check the performance is still OK.