### PR TITLE
Fix basic auth on notary cli

### DIFF
--- a/cmd/notary/tuf.go
+++ b/cmd/notary/tuf.go
@@ -949,8 +949,6 @@ func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun data.GU
 		return nil, err
 	}
 
-	ps := passwordStore{anonymous: permission == readOnly}
-
 	var actions []string
 	switch permission {
 	case admin:
@@ -963,8 +961,8 @@ func tokenAuth(trustServerURL string, baseTransport *http.Transport, gun data.GU
 		return nil, fmt.Errorf("Invalid permission requested for token authentication of gun %s", gun)
 	}
 
-	tokenHandler := auth.NewTokenHandler(authTransport, ps, gun.String(), actions...)
-	basicHandler := auth.NewBasicHandler(ps)
+	tokenHandler := auth.NewTokenHandler(authTransport, passwordStore{anonymous: permission == readOnly}, gun.String(), actions...)
+	basicHandler := auth.NewBasicHandler(passwordStore{anonymous: false}) // non-anonymous access will be required when basic challenge is returned
 
 	modifier := auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler)
 


### PR DESCRIPTION
When notary-server is protected with Basic authentication (namely returns 401 and `WWW-Authenticate: Basic`), notary cli fails with `no basic auth credentials` error for `readOnly` API accesses. It is because `basicHandler` is created with anonymous passwordStore in that case.

I fixed this issue with forcing non-anonymous access for basic challenges. It only affects notary-servers that are protected with Basic authentication.
