### PR TITLE
server: use docker/go-metrics utilities for prometheus, add "no_metrics" build-tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ CTIMEVAR=-X $(NOTARY_PKG)/version.GitCommit=$(GITCOMMIT) -X $(NOTARY_PKG)/versio
 GO_LDFLAGS=-ldflags "-w $(CTIMEVAR)"
 GO_LDFLAGS_STATIC=-ldflags "-w $(CTIMEVAR) -extldflags -static"
 GOOSES = darwin linux windows
+
+# Available build-tags:
+#
+# - pkcs11      enables pkcs11 integration
+# - no_metrics  removes prometheus metrics and the /metrics endpoint
 NOTARY_BUILDTAGS ?= pkcs11
 NOTARYDIR := /go/src/github.com/theupdateframework/notary
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c
 	github.com/docker/go-connections v0.4.0
+	github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916
 	github.com/dvsekhvalnov/jose2go v0.0.0-20200901110807-248326c1351b
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/golang/protobuf v1.5.2
@@ -17,7 +18,6 @@ require (
 	github.com/lib/pq v1.9.0
 	github.com/mattn/go-sqlite3 v1.14.0
 	github.com/miekg/pkcs11 v1.0.3
-	github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/viper v0.0.0-20150530192845-be5ff3e4840c
@@ -39,7 +39,6 @@ require (
 	github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73 // indirect
-	github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/gogo/protobuf v1.0.0 // indirect
 	github.com/google/certificate-transparency-go v1.0.10-0.20180222191210-5ab67e519c93 // indirect
@@ -58,6 +57,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v0.9.0-pre1.0.20180209125602-c332b6f63c06 // indirect
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/common v0.0.0-20180110214958-89604d197083 // indirect
 	github.com/prometheus/procfs v0.0.0-20180125133057-cb4147076ac7 // indirect

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/docker/go-metrics"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// namespacePrefix is the namespace prefix used for prometheus metrics.
+const namespacePrefix = "notary_server"
+
+func prometheusOpts(operation string) prometheus.SummaryOpts {
+	return prometheus.SummaryOpts{
+		Namespace:   namespacePrefix,
+		Subsystem:   "http",
+		ConstLabels: prometheus.Labels{"operation": operation},
+	}
+}
+
+// instrumentedHandler instruments a server handler for monitoring with prometheus.
+func instrumentedHandler(handlerName string, handler http.Handler) http.Handler {
+	return prometheus.InstrumentHandlerFuncWithOpts(prometheusOpts(handlerName), handler.ServeHTTP) //lint:ignore SA1019 TODO update prometheus API
+}
+
+// handleMetricsEndpoint registers the /metrics endpoint.
+func handleMetricsEndpoint(r *mux.Router) {
+	r.Methods("GET").Path("/metrics").Handler(metrics.Handler())
+}

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,3 +1,6 @@
+//go:build !no_metrics
+// +build !no_metrics
+
 package server
 
 import (

--- a/server/metrics_disabled.go
+++ b/server/metrics_disabled.go
@@ -1,0 +1,14 @@
+//go:build no_metrics
+// +build no_metrics
+
+package server
+
+import "net/http"
+
+// instrumentedHandler instruments a server handler for monitoring with prometheus.
+func instrumentedHandler(_ string, handler http.Handler) http.Handler {
+	return handler
+}
+
+// handleMetricsEndpoint registers the /metrics endpoint.
+func handleMetricsEndpoint(r *interface{}) {}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,0 +1,22 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/notary/tuf/signed"
+)
+
+func TestMetricsEndpoint(t *testing.T) {
+	handler := RootHandler(context.Background(), nil, signed.NewEd25519(),
+		nil, nil, nil)
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL + "/metrics")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}

--- a/server/metrics_test.go
+++ b/server/metrics_test.go
@@ -1,3 +1,6 @@
+//go:build !no_metrics
+// +build !no_metrics
+
 package server
 
 import (

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -140,17 +140,6 @@ func TestRepoPrefixDoesNotMatch(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
-func TestMetricsEndpoint(t *testing.T) {
-	handler := RootHandler(context.Background(), nil, signed.NewEd25519(),
-		nil, nil, nil)
-	ts := httptest.NewServer(handler)
-	defer ts.Close()
-
-	res, err := http.Get(ts.URL + "/metrics")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
-}
-
 // GetKeys supports only the timestamp and snapshot key endpoints
 func TestGetKeysEndpoint(t *testing.T) {
 	ctx := context.WithValue(


### PR DESCRIPTION
The old code was no longer compatible with current versions of prometheus.
This switches the code to use docker/go-metrics, which is compatible with
current versions of prometheus, and already in use in other code in the
dependency tree.

I tried to keep the metrics the same as before, but there may be some
differences.


The first commit separates the metrics code from the server file; second commit introduces a `no_metrics` build-tag to allow building without metrics.