### PR TITLE
Nominating jonnystoten for notary repo maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -18,6 +18,7 @@
 		people = [
 			"hukeping",
 			"justincormack",
+			"jonnystoten"
 		]
 
 	[Org."Notation maintainers"]
@@ -64,3 +65,8 @@
 	Name = "Steve Lasker"
 	Email = "Steve.Lasker@microsoft.com"
 	GitHub = "stevelasker"
+
+	[people.jonnystoten]
+	Name = "Jonny Stoten"
+	Email = "jonny.stoten@docker.com"
+	GitHub = "jonnystoten"


### PR DESCRIPTION
As per @justincormack suggestion, I am nominating @jonnystoten as a maintainer for this repository. According to Justin, Jonny will be maintaining the old implementation of Notary used by Docker Content Trust. I am leaving to the current maintainers to approve this change. Once approved, we need to update the CODEOWNERS (see #1673) with Jonny's handle. 