### PR TITLE
Explicitly set the actions required in the authentication

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -197,7 +197,7 @@ func RootHandler(ctx context.Context, ac auth.AccessController, trust signed.Cry
 		notFoundError,
 		false,
 		nil,
-		[]string{"*"},
+		[]string{"pull", "push", "delete"},
 		authWrapper,
 		repoPrefixes,
 	))
@@ -207,7 +207,7 @@ func RootHandler(ctx context.Context, ac auth.AccessController, trust signed.Cry
 		notFoundError,
 		false,
 		nil,
-		[]string{"*"},
+		[]string{"pull", "push", "delete"},
 		authWrapper,
 		repoPrefixes,
 	))
@@ -227,7 +227,7 @@ func RootHandler(ctx context.Context, ac auth.AccessController, trust signed.Cry
 		notFoundError,
 		false,
 		nil,
-		[]string{"*"},
+		[]string{"pull", "push", "delete"},
 		authWrapper,
 		repoPrefixes,
 	))


### PR DESCRIPTION
Instead of using the action `*`, explicitly request the actions that
will be needed.
